### PR TITLE
fix carrier respawn to ovoid the cat

### DIFF
--- a/game.py
+++ b/game.py
@@ -260,7 +260,7 @@ while running:
             reset()
         menu_screen = True
         
-        goal.respawn()
+        goal.respawn(cat.rect.x, cat.rect.y)
         carrier.add(goal)
 
     # *after* drawing everything, flip the display

--- a/objects/cat_carrier.py
+++ b/objects/cat_carrier.py
@@ -16,6 +16,19 @@ class Carrier(pygame.sprite.Sprite):
         self.rect.x = random.randrange(WIDTH-self.width)
         self.rect.y = random.randrange(self.height, HEIGHT-self.height)
 
-    def respawn(self):
-        self.rect.x = random.randrange(WIDTH-self.width)
-        self.rect.y = random.randrange(self.height, HEIGHT-self.height)
+    def respawn(self, cat_x, cat_y):
+        if cat_x < WIDTH // 2 and cat_y < HEIGHT // 2:
+            self.rect.x = random.randrange(WIDTH//2, WIDTH-self.width)
+            self.rect.y = random.randrange(HEIGHT//2, HEIGHT-self.height)
+        elif cat_x > WIDTH // 2 and cat_y < HEIGHT // 2:
+            self.rect.x = random.randrange(WIDTH//2)
+            self.rect.y = random.randrange(HEIGHT//2, HEIGHT-self.height)
+        elif cat_x > WIDTH // 2 and cat_y > HEIGHT // 2:
+            self.rect.x = random.randrange(WIDTH//2)
+            self.rect.y = random.randrange(self.height, HEIGHT//2)
+        elif cat_x < WIDTH // 2 and cat_y > HEIGHT // 2:
+            self.rect.x = random.randrange(WIDTH//2, WIDTH-self.width)
+            self.rect.y = random.randrange(self.height, HEIGHT//2)
+        else:
+            self.rect.x = random.randrange(WIDTH-self.width)
+            self.rect.y = random.randrange(self.height, HEIGHT-self.height)


### PR DESCRIPTION
I changed the carrier respawn function to check the cat.rect.x and cat.rect.y and respawn in the opposite quadrant. We could adjust this, but it seems to very rarely spawn a the same location.  